### PR TITLE
fix: Resolve TypeScript error with cookie handling

### DIFF
--- a/src/app/api/movies/route.ts
+++ b/src/app/api/movies/route.ts
@@ -6,7 +6,7 @@ import { isAuthenticated } from '@/lib/auth';
 export async function POST(req: NextRequest) {
   await dbConnect();
 
-  if (!isAuthenticated()) {
+  if (!isAuthenticated(req)) {
     return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,11 +1,10 @@
 import { verify } from 'jsonwebtoken';
-import { cookies } from 'next/headers';
+import { NextRequest } from 'next/server';
 
 const JWT_SECRET = "a-secure-and-random-secret-for-jwt";
 
-export function isAuthenticated(): boolean {
-  const cookieStore = cookies();
-  const token = cookieStore.get('auth_token')?.value;
+export function isAuthenticated(req: NextRequest): boolean {
+  const token = req.cookies.get('auth_token')?.value;
 
   if (!token) {
     return false;


### PR DESCRIPTION
This commit fixes a TypeScript type error (`Property 'get' does not exist on type 'Promise<ReadonlyRequestCookies>'`) that was causing the Vercel build to fail.

The `isAuthenticated` utility function in `src/lib/auth.ts` has been refactored to accept the `NextRequest` object as a parameter. It now reads the authentication cookie directly from the request object's `cookies` property instead of using the `cookies()` helper from `next/headers`.

The `POST /api/movies` endpoint has been updated to pass the request object to the `isAuthenticated` function. This change resolves the build error and ensures reliable cookie handling in the Vercel environment.