### PR TITLE
fix: Handle Promise-based context in Vercel build environment

### DIFF
--- a/src/app/api/movies/[id]/route.ts
+++ b/src/app/api/movies/[id]/route.ts
@@ -3,10 +3,12 @@ import dbConnect from '@/lib/db';
 import Movie from '@/models/Movie';
 import { isAuthenticated } from '@/lib/auth';
 
+// The context object's params property is a Promise in the Vercel build environment.
+// This type definition matches the expected signature from the build error log.
 interface Context {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
 // Handler for updating a movie
@@ -18,7 +20,7 @@ export async function PUT(req: NextRequest, context: Context) {
   }
 
   try {
-    const { id } = context.params;
+    const { id } = await context.params; // Await the promise to resolve the params
     const { name, image, link } = await req.json();
 
     if (!name || !image || !link || (Array.isArray(link) && link.length === 0)) {
@@ -51,7 +53,7 @@ export async function DELETE(req: NextRequest, context: Context) {
   }
 
   try {
-    const { id } = context.params;
+    const { id } = await context.params; // Await the promise to resolve the params
     const deletedMovie = await Movie.findByIdAndDelete(id);
 
     if (!deletedMovie) {


### PR DESCRIPTION
This commit resolves a persistent and highly specific TypeScript build error that occurred only in the Vercel deployment environment.

The build logs indicated that the `context.params` object in the dynamic API route was being treated as a `Promise`, causing a type mismatch. This commit updates the type definition for the `Context` object to reflect this `Promise`-based structure and adds `await` when accessing `context.params`.

This change is specifically tailored to resolve the Vercel build failure and should allow the project to deploy successfully.