### PR TITLE
fix: Restore hover color for movie titles

### DIFF
--- a/src/app/[page]/page.tsx
+++ b/src/app/[page]/page.tsx
@@ -134,7 +134,7 @@ export default function Page({ params }: PageProps) {
                     loading="lazy"
                   />
                   <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/80 to-transparent p-2">
-                    <p className="font-bold text-white text-sm leading-tight line-clamp-2">{movie.name}</p>
+                    <p className="font-bold text-white text-sm leading-tight line-clamp-2 transition-colors duration-300 group-hover:text-red-400">{movie.name}</p>
                   </div>
                 </div>
               </a>


### PR DESCRIPTION
This commit restores the red hover effect for the movie titles on the main page, which was accidentally removed in a previous change.

The `group-hover:text-red-400` class has been added back to the movie title element, ensuring that the title changes color when the user hovers over the movie poster. This provides better visual feedback and a more interactive user experience.