### PR TITLE
Fix: Resolve build errors and optimize image loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "eslint": "^9",
         "eslint-config-next": "15.5.4",
         "tailwindcss": "^4",
@@ -1360,6 +1361,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",

--- a/src/app/[page]/page.tsx
+++ b/src/app/[page]/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, use } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link'; // Import the Next.js Link component
+import Image from 'next/image';
 
 // Update the interface to match the new schema with downloadLinks
 interface Movie {
@@ -17,12 +18,13 @@ interface Movie {
 }
 
 interface PageProps {
-  params: {
+  params: Promise<{
     page: string;
-  };
+  }>;
 }
 
-export default function Page({ params }: PageProps) {
+export default function Page(props: PageProps) {
+  const params = use(props.params);
   const [movies, setMovies] = useState<Movie[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -197,10 +199,12 @@ export default function Page({ params }: PageProps) {
             {movies.map((movie) => (
               <Link key={movie._id} href={`/movie/${movie._id}`} className="block group">
                 <div className="relative aspect-[2/3] overflow-hidden rounded-lg shadow-lg bg-gray-800">
-                  <img
+                  <Image
                     src={movie.image}
                     alt={movie.name}
-                    className="absolute h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    fill
+                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, (max-width: 1280px) 20vw, 16.6vw"
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
                     loading="lazy"
                   />
                 </div>

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
+import Image from 'next/image';
 
 interface Movie {
   _id: string;
@@ -62,7 +63,13 @@ export default function MovieDetailsPage() {
       <div className="mx-auto max-w-4xl">
         <div className="flex flex-col md:flex-row gap-8">
           <div className="md:w-1/3">
-            <img src={movie.image} alt={movie.name} className="w-full h-auto rounded-lg shadow-lg" />
+            <Image
+              src={movie.image}
+              alt={movie.name}
+              width={500}
+              height={750}
+              className="w-full h-auto rounded-lg shadow-lg"
+            />
           </div>
           <div className="md:w-2/3">
             <h1 className="text-4xl font-bold mb-4">{movie.name}</h1>


### PR DESCRIPTION
This commit addresses two issues:
1.  A TypeScript compilation error caused by a missing type definition for the `web-push` library. This was fixed by adding `@types/web-push` as a dev dependency.
2.  ESLint warnings related to using `<img>` tags instead of the `next/image` component. The `<img>` tags in `src/app/[page]/page.tsx` and `src/app/movie/[id]/page.tsx` have been replaced with the `Image` component to improve performance and follow best practices.

Additionally, the `next-async-request-api` codemod was run to address a breaking change in Next.js 15 related to asynchronous `params` in Client Components.